### PR TITLE
added a check to click the button if it is there when assigning the mutation observer

### DIFF
--- a/Auto Click Channel Points.user.js
+++ b/Auto Click Channel Points.user.js
@@ -24,6 +24,14 @@ function monitorSpecificElement() {
     }
     else {
         console.log('Target element found:', targetElement);
+        // Check if the button is already present
+        const claimBonusButton = targetElement.querySelector('[aria-label="Claim Bonus"]');
+        if (claimBonusButton) {
+            console.log('Claim Bonus button already present:', claimBonusButton);
+            claimBonusButton.click();
+        } else {
+            console.log('Claim Bonus button not found in the target element.');
+        }
     }
 
     const observer = new MutationObserver((mutations) => {


### PR DESCRIPTION
Seems to work, it will be hard to tell unless I ever wind up in the corner case where the button hasn't been pressed.